### PR TITLE
add-test-workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ PLUGIN_DEPENDENCIES := $(shell find . -name "*.go")
 # if you want to execute gotest with verbosity, set this flag to `true`.
 TEST_VERBOSE ?= true
 
+.PHONY: build init format test install
 build: format test $(PLUGIN_BIN)
 
 init:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,26 @@
+SHELL := /bin/bash
+INSTALL_DIR ?= /usr/bin
+PLUGIN_BIN ?= github-stats
+PLUGIN_DEPENDENCIES := $(shell find . -name "*.go")
+# if you want to execute gotest with verbosity, set this flag to `true`.
+TEST_VERBOSE ?= true
+
+build: format test $(PLUGIN_BIN)
+
+init:
+	aqua install
+
+format:
+	go fmt ./...
+
+test:
+ifeq ($(TEST_VERBOSE), true)
+	go test -v ./... -race -count=1
+else
+	go test ./... -race -count=1
+endif
+
+$(PLUGIN_BIN): $(PLUGIN_DEPENDENCIES)
+	go build -o $(PLUGIN_BIN) ./main.go
+
+install: $(PLUGIN_BIN)

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -1,0 +1,15 @@
+---
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+# checksum:
+#   enabled: true
+#   require_checksum: true
+#   supported_envs:
+#   - all
+registries:
+  - type: standard
+    ref: v4.271.0 # renovate: depName=aquaproj/aqua-registry
+packages:
+  - name: golang/go
+    go_version_file: go.mod
+

--- a/cover.html
+++ b/cover.html
@@ -1,0 +1,506 @@
+
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+		<title>cmd: Go Coverage Report</title>
+		<style>
+			body {
+				background: black;
+				color: rgb(80, 80, 80);
+			}
+			body, pre, #legend span {
+				font-family: Menlo, monospace;
+				font-weight: bold;
+			}
+			#topbar {
+				background: black;
+				position: fixed;
+				top: 0; left: 0; right: 0;
+				height: 42px;
+				border-bottom: 1px solid rgb(80, 80, 80);
+			}
+			#content {
+				margin-top: 50px;
+			}
+			#nav, #legend {
+				float: left;
+				margin-left: 10px;
+			}
+			#legend {
+				margin-top: 12px;
+			}
+			#nav {
+				margin-top: 10px;
+			}
+			#legend span {
+				margin: 0 5px;
+			}
+			.cov0 { color: rgb(192, 0, 0) }
+.cov1 { color: rgb(128, 128, 128) }
+.cov2 { color: rgb(116, 140, 131) }
+.cov3 { color: rgb(104, 152, 134) }
+.cov4 { color: rgb(92, 164, 137) }
+.cov5 { color: rgb(80, 176, 140) }
+.cov6 { color: rgb(68, 188, 143) }
+.cov7 { color: rgb(56, 200, 146) }
+.cov8 { color: rgb(44, 212, 149) }
+.cov9 { color: rgb(32, 224, 152) }
+.cov10 { color: rgb(20, 236, 155) }
+
+		</style>
+	</head>
+	<body>
+		<div id="topbar">
+			<div id="nav">
+				<select id="files">
+				
+				<option value="file0">github.com/naka-gawa/github-stats/cmd/root.go (0.0%)</option>
+				
+				<option value="file1">github.com/naka-gawa/github-stats/cmd/stats.go (0.0%)</option>
+				
+				<option value="file2">github.com/naka-gawa/github-stats/internal/gateway/github.go (77.3%)</option>
+				
+				<option value="file3">github.com/naka-gawa/github-stats/internal/usecase/aggregator.go (97.4%)</option>
+				
+				<option value="file4">github.com/naka-gawa/github-stats/main.go (0.0%)</option>
+				
+				</select>
+			</div>
+			<div id="legend">
+				<span>not tracked</span>
+			
+				<span class="cov0">not covered</span>
+				<span class="cov8">covered</span>
+			
+			</div>
+		</div>
+		<div id="content">
+		
+		<pre class="file" id="file0" style="display: none">// Package cmd contains all the CLI commands for the application,
+// built using the Cobra library.
+package cmd
+
+import (
+        "os"
+
+        "github.com/spf13/cobra"
+)
+
+var rootCmd = &amp;cobra.Command{
+        Use:   "github-stats",
+        Short: "A CLI tool to aggregate GitHub user contributions.",
+        Long: `github-stats is a CLI tool that aggregates a user's contributions
+(commits, PRs created/reviewed) per repository within a GitHub organization.
+You can specify a date range to filter the results.`,
+}
+
+// Execute adds all child commands to the root command and sets flags appropriately.
+// This is called by main.main(). It only needs to happen once to the rootCmd.
+func Execute() <span class="cov0" title="0">{
+        err := rootCmd.Execute()
+        if err != nil </span><span class="cov0" title="0">{
+                os.Exit(1)
+        }</span>
+}
+
+func init() <span class="cov0" title="0">{
+        // Add a persistent flag for verbose output, available to all commands.
+        rootCmd.PersistentFlags().BoolP("verbose", "v", false, "Enable verbose/debug logging")
+}</span>
+</pre>
+		
+		<pre class="file" id="file1" style="display: none">// Package cmd contains all the CLI commands for the application,
+// built using the Cobra library.
+package cmd
+
+import (
+        "context"
+        "encoding/json"
+        "fmt"
+        "io"
+        "log"
+        "os"
+        "time"
+
+        "github.com/naka-gawa/github-stats/internal/gateway"
+        "github.com/naka-gawa/github-stats/internal/usecase"
+        "github.com/spf13/cobra"
+)
+
+var statsCmd = &amp;cobra.Command{
+        Use:   "stats",
+        Short: "Aggregates GitHub user activity and outputs as JSON",
+        Long:  `Aggregates activity (commits, created/reviewed PRs) for a specified GitHub user and organization, and outputs the result in JSON format.`,
+        Run: func(cmd *cobra.Command, args []string) <span class="cov0" title="0">{
+                ctx := context.Background()
+
+                // Get the verbose flag from the root command to set up the logger.
+                // The flag is now correctly defined on rootCmd.
+                verbose, _ := cmd.InheritedFlags().GetBool("verbose")
+                logger := log.New(io.Discard, "", log.LstdFlags) // Default: discard all logs.
+                if verbose </span><span class="cov0" title="0">{
+                        logger.SetOutput(os.Stderr) // If verbose, log to standard error.
+                }</span>
+
+                // Get other flags.
+                <span class="cov0" title="0">org, _ := cmd.Flags().GetString("org")
+                user, _ := cmd.Flags().GetString("user")
+                fromStr, _ := cmd.Flags().GetString("from")
+                toStr, _ := cmd.Flags().GetString("to")
+                token := os.Getenv("GITHUB_TOKEN")
+                if token == "" </span><span class="cov0" title="0">{
+                        fmt.Fprintln(os.Stderr, "Error: GITHUB_TOKEN environment variable is not set.")
+                        os.Exit(1)
+                }</span>
+
+                // Build date range query strings.
+                // NOTE: Commit search uses "author-date", while PR search uses "created".
+                <span class="cov0" title="0">var commitDateRange, prDateRange string
+                if fromStr != "" || toStr != "" </span><span class="cov0" title="0">{
+                        const githubDateLayout = "2006-01-02"
+                        const inputDateLayout = "2006/01/02"
+                        fromQuery := "*"
+                        if fromStr != "" </span><span class="cov0" title="0">{
+                                fromTime, err := time.Parse(inputDateLayout, fromStr)
+                                if err != nil </span><span class="cov0" title="0">{
+                                        fmt.Fprintf(os.Stderr, "Invalid --from date format. Please use YYYY/MM/DD. Error: %v\n", err)
+                                        os.Exit(1)
+                                }</span>
+                                <span class="cov0" title="0">fromQuery = fromTime.Format(githubDateLayout)</span>
+                        }
+                        <span class="cov0" title="0">toQuery := "*"
+                        if toStr != "" </span><span class="cov0" title="0">{
+                                toTime, err := time.Parse(inputDateLayout, toStr)
+                                if err != nil </span><span class="cov0" title="0">{
+                                        fmt.Fprintf(os.Stderr, "Invalid --to date format. Please use YYYY/MM/DD. Error: %v\n", err)
+                                        os.Exit(1)
+                                }</span>
+                                <span class="cov0" title="0">toQuery = toTime.Format(githubDateLayout)</span>
+                        }
+                        // Note: The leading space is important for concatenation.
+                        <span class="cov0" title="0">commitDateRange = fmt.Sprintf(" author-date:%s..%s", fromQuery, toQuery)
+                        prDateRange = fmt.Sprintf(" created:%s..%s", fromQuery, toQuery)</span>
+                }
+
+                // Inject dependencies and run the main business logic.
+                <span class="cov0" title="0">githubGateway, err := gateway.NewGitHubGateway(token, logger)
+                if err != nil </span><span class="cov0" title="0">{
+                        fmt.Fprintf(os.Stderr, "Failed to create GitHub gateway: %v\n", err)
+                        os.Exit(1)
+                }</span>
+                <span class="cov0" title="0">aggregator := usecase.NewAggregator(githubGateway, logger)
+
+                // Pass the correct date ranges to the aggregator
+                results, err := aggregator.Aggregate(ctx, org, user, commitDateRange, prDateRange)
+                if err != nil </span><span class="cov0" title="0">{
+                        fmt.Fprintf(os.Stderr, "Failed to aggregate stats: %v\n", err)
+                        os.Exit(1)
+                }</span>
+
+                // Marshal the results into a pretty-printed JSON string.
+                <span class="cov0" title="0">jsonData, err := json.MarshalIndent(results, "", "  ")
+                if err != nil </span><span class="cov0" title="0">{
+                        fmt.Fprintf(os.Stderr, "Failed to marshal results to JSON: %v\n", err)
+                        os.Exit(1)
+                }</span>
+
+                // Print the final JSON to standard output.
+                <span class="cov0" title="0">fmt.Println(string(jsonData))</span>
+        },
+}
+
+func init() <span class="cov0" title="0">{
+        rootCmd.AddCommand(statsCmd)
+        statsCmd.PersistentFlags().StringP("org", "o", "", "Target GitHub organization name (required)")
+        statsCmd.PersistentFlags().StringP("user", "u", "", "Target GitHub user name (required)")
+        statsCmd.MarkPersistentFlagRequired("org")
+        statsCmd.MarkPersistentFlagRequired("user")
+        statsCmd.Flags().String("from", "", "Start date for stats (YYYY/MM/DD)")
+        statsCmd.Flags().String("to", "", "End date for stats (YYYY/MM/DD)")
+}</span>
+</pre>
+		
+		<pre class="file" id="file2" style="display: none">// Package gateway provides a gateway to the GitHub API,
+// abstracting away the underlying REST and GraphQL clients.
+package gateway
+
+import (
+        "context"
+        "fmt"
+        "log"
+        "net/http"
+        "time"
+
+        "github.com/google/go-github/v62/github"
+        "github.com/shurcooL/githubv4"
+        "golang.org/x/oauth2"
+
+        "github.com/gofri/go-github-ratelimit/github_ratelimit"
+)
+
+// Fetcher defines the behavior of a gateway for fetching information from GitHub.
+// By defining an interface, we can easily mock this gateway in our tests.
+type Fetcher interface {
+        FetchCommits(ctx context.Context, org, user, dateRange string) (map[string]int, error)
+        FetchCreatedPRs(ctx context.Context, org, user, dateRange string) (map[string]int, error)
+        FetchReviewedPRs(ctx context.Context, org, user, dateRange string) (map[string]int, error)
+}
+
+// GitHubGateway is the concrete implementation of the Fetcher interface.
+type GitHubGateway struct {
+        restClient    *github.Client
+        graphqlClient *githubv4.Client
+        logger        *log.Logger
+}
+
+// searchIssuesQuery defines the structure for the GraphQL response.
+type searchIssuesQuery struct {
+        Search struct {
+                PageInfo struct {
+                        HasNextPage bool
+                        EndCursor   githubv4.String
+                }
+                Edges []struct {
+                        Node struct {
+                                Typename    string `graphql:"__typename"`
+                                PullRequest struct {
+                                        Repository struct {
+                                                NameWithOwner string
+                                        }
+                                } `graphql:"... on PullRequest"`
+                        }
+                }
+        } `graphql:"search(query: $query, type: ISSUE, first: 100, after: $cursor)"`
+}
+
+// NewGitHubGateway is a constructor that creates a new instance of GitHubGateway.
+func NewGitHubGateway(token string, logger *log.Logger) (Fetcher, error) <span class="cov0" title="0">{
+        rateLimitWaiter, err := github_ratelimit.NewRateLimitWaiter(nil, github_ratelimit.WithSingleSleepLimit(1*time.Hour, nil))
+        if err != nil </span><span class="cov0" title="0">{
+                return nil, fmt.Errorf("failed to create rate limit waiter: %w", err)
+        }</span>
+        <span class="cov0" title="0">ts := oauth2.StaticTokenSource(&amp;oauth2.Token{AccessToken: token})
+        httpClient := &amp;http.Client{
+                Transport: &amp;oauth2.Transport{
+                        Base:   rateLimitWaiter,
+                        Source: ts,
+                },
+        }
+        return &amp;GitHubGateway{
+                restClient:    github.NewClient(httpClient),
+                graphqlClient: githubv4.NewClient(httpClient),
+                logger:        logger,
+        }, nil</span>
+}
+
+// FetchCommits retrieves commit information using the REST API and returns a map of repository names to their commit counts.
+func (g *GitHubGateway) FetchCommits(ctx context.Context, org, user, dateRange string) (map[string]int, error) <span class="cov8" title="1">{
+        g.logger.Println("[1/3] Fetching commit data using REST API...")
+        query := fmt.Sprintf("org:%s author:%s%s", org, user, dateRange)
+        opts := &amp;github.SearchOptions{
+                ListOptions: github.ListOptions{PerPage: 100},
+        }
+        commitCounts := make(map[string]int)
+        for </span><span class="cov8" title="1">{
+                result, resp, err := g.restClient.Search.Commits(ctx, query, opts)
+                if err != nil </span><span class="cov8" title="1">{
+                        return nil, fmt.Errorf("failed to search commits with REST API: %w", err)
+                }</span>
+                <span class="cov8" title="1">for _, commit := range result.Commits </span><span class="cov8" title="1">{
+                        repoName := commit.GetRepository().GetFullName()
+                        commitCounts[repoName]++
+                }</span>
+                <span class="cov8" title="1">if resp.NextPage == 0 </span><span class="cov8" title="1">{
+                        break</span>
+                }
+                <span class="cov0" title="0">opts.Page = resp.NextPage
+                g.logger.Println("  Fetching next page of commits...")</span>
+        }
+        <span class="cov8" title="1">g.logger.Println("Completed fetching commit data.")
+        return commitCounts, nil</span>
+}
+
+// FetchCreatedPRs retrieves created pull request information using the GraphQL API.
+func (g *GitHubGateway) FetchCreatedPRs(ctx context.Context, org, user, dateRange string) (map[string]int, error) <span class="cov8" title="1">{
+        g.logger.Println("[2/3] Fetching created PR data...")
+        query := fmt.Sprintf("org:%s author:%s is:pr%s", org, user, dateRange)
+        return g.fetchPRs(ctx, query)
+}</span>
+
+// FetchReviewedPRs retrieves reviewed pull request information using the GraphQL API.
+func (g *GitHubGateway) FetchReviewedPRs(ctx context.Context, org, user, dateRange string) (map[string]int, error) <span class="cov8" title="1">{
+        g.logger.Println("[3/3] Fetching reviewed PR data...")
+        query := fmt.Sprintf("org:%s reviewed-by:%s is:pr%s", org, user, dateRange)
+        return g.fetchPRs(ctx, query)
+}</span>
+
+// fetchPRs is a helper function to avoid duplicating the GraphQL query logic.
+func (g *GitHubGateway) fetchPRs(ctx context.Context, query string) (map[string]int, error) <span class="cov8" title="1">{
+        variables := map[string]interface{}{
+                "query":  githubv4.String(query),
+                "cursor": (*githubv4.String)(nil),
+        }
+        prCounts := make(map[string]int)
+        for </span><span class="cov8" title="1">{
+                var q searchIssuesQuery
+                if err := g.graphqlClient.Query(ctx, &amp;q, variables); err != nil </span><span class="cov8" title="1">{
+                        return nil, fmt.Errorf("failed to execute GraphQL query: %w", err)
+                }</span>
+                <span class="cov8" title="1">for _, edge := range q.Search.Edges </span><span class="cov8" title="1">{
+                        if repoName := edge.Node.PullRequest.Repository.NameWithOwner; repoName != "" </span><span class="cov8" title="1">{
+                                prCounts[repoName]++
+                        }</span>
+                }
+                <span class="cov8" title="1">if !q.Search.PageInfo.HasNextPage </span><span class="cov8" title="1">{
+                        break</span>
+                }
+                <span class="cov0" title="0">variables["cursor"] = githubv4.NewString(q.Search.PageInfo.EndCursor)
+                g.logger.Println("  Fetching next page of pull requests...")</span>
+        }
+        <span class="cov8" title="1">g.logger.Printf("Completed fetching pull requests for query: %s\n", query)
+        return prCounts, nil</span>
+}
+</pre>
+		
+		<pre class="file" id="file3" style="display: none">// Package usecase contains the business logic of the application.
+package usecase
+
+import (
+        "context"
+        "log"
+        "sort"
+
+        "github.com/naka-gawa/github-stats/internal/domain"
+        "github.com/naka-gawa/github-stats/internal/gateway"
+        "golang.org/x/sync/errgroup"
+)
+
+// Aggregator is the use case for aggregating GitHub stats.
+// It orchestrates the fetching and combining of data.
+type Aggregator struct {
+        fetcher gateway.Fetcher
+        logger  *log.Logger
+}
+
+// NewAggregator creates a new Aggregator instance.
+func NewAggregator(fetcher gateway.Fetcher, logger *log.Logger) *Aggregator <span class="cov8" title="1">{
+        return &amp;Aggregator{
+                fetcher: fetcher,
+                logger:  logger,
+        }
+}</span>
+
+// Aggregate performs the main business logic: it fetches all required data concurrently
+// from the gateway and aggregates it into a final, sorted slice of stats.
+func (a *Aggregator) Aggregate(ctx context.Context, org, user, commitDateRange, prDateRange string) ([]*domain.RepoStats, error) <span class="cov8" title="1">{
+        a.logger.Println("Usecase: Starting data aggregation...")
+
+        var commitCounts, createdPRCounts, reviewedPRCounts map[string]int
+
+        // Use an errgroup to fetch all data concurrently.
+        // If any of the fetch operations fail, the whole group will be cancelled.
+        eg, egCtx := errgroup.WithContext(ctx)
+
+        eg.Go(func() error </span><span class="cov8" title="1">{
+                var err error
+                commitCounts, err = a.fetcher.FetchCommits(egCtx, org, user, commitDateRange)
+                return err
+        }</span>)
+
+        <span class="cov8" title="1">eg.Go(func() error </span><span class="cov8" title="1">{
+                var err error
+                createdPRCounts, err = a.fetcher.FetchCreatedPRs(egCtx, org, user, prDateRange)
+                return err
+        }</span>)
+
+        <span class="cov8" title="1">eg.Go(func() error </span><span class="cov8" title="1">{
+                var err error
+                reviewedPRCounts, err = a.fetcher.FetchReviewedPRs(egCtx, org, user, prDateRange)
+                return err
+        }</span>)
+
+        <span class="cov8" title="1">if err := eg.Wait(); err != nil </span><span class="cov8" title="1">{
+                return nil, err
+        }</span>
+        <span class="cov8" title="1">a.logger.Println("Usecase: All data fetched successfully.")
+
+        // Merge all results into a single map.
+        statsMap := make(map[string]*domain.RepoStats)
+
+        for repoName, count := range commitCounts </span><span class="cov8" title="1">{
+                if _, ok := statsMap[repoName]; !ok </span><span class="cov8" title="1">{
+                        statsMap[repoName] = &amp;domain.RepoStats{Name: repoName}
+                }</span>
+                <span class="cov8" title="1">statsMap[repoName].Commits = count</span>
+        }
+        <span class="cov8" title="1">for repoName, count := range createdPRCounts </span><span class="cov8" title="1">{
+                if _, ok := statsMap[repoName]; !ok </span><span class="cov8" title="1">{
+                        statsMap[repoName] = &amp;domain.RepoStats{Name: repoName}
+                }</span>
+                <span class="cov8" title="1">statsMap[repoName].CreatedPRs = count</span>
+        }
+        <span class="cov8" title="1">for repoName, count := range reviewedPRCounts </span><span class="cov8" title="1">{
+                if _, ok := statsMap[repoName]; !ok </span><span class="cov0" title="0">{
+                        statsMap[repoName] = &amp;domain.RepoStats{Name: repoName}
+                }</span>
+                <span class="cov8" title="1">statsMap[repoName].ReviewedPRs = count</span>
+        }
+
+        // Convert the map to a slice and sort it by repository name for consistent output.
+        <span class="cov8" title="1">sortedStats := make([]*domain.RepoStats, 0)
+        for _, repoStat := range statsMap </span><span class="cov8" title="1">{
+                sortedStats = append(sortedStats, repoStat)
+        }</span>
+        <span class="cov8" title="1">sort.Slice(sortedStats, func(i, j int) bool </span><span class="cov8" title="1">{
+                return sortedStats[i].Name &lt; sortedStats[j].Name
+        }</span>)
+
+        <span class="cov8" title="1">a.logger.Println("Usecase: Aggregation complete.")
+        return sortedStats, nil</span>
+}
+</pre>
+		
+		<pre class="file" id="file4" style="display: none">/*
+Copyright © 2025 NAME HERE &lt;EMAIL ADDRESS&gt;
+
+*/
+package main
+
+import "github.com/naka-gawa/github-stats/cmd"
+
+func main() <span class="cov0" title="0">{
+        cmd.Execute()
+}</span>
+</pre>
+		
+		</div>
+	</body>
+	<script>
+	(function() {
+		var files = document.getElementById('files');
+		var visible;
+		files.addEventListener('change', onChange, false);
+		function select(part) {
+			if (visible)
+				visible.style.display = 'none';
+			visible = document.getElementById(part);
+			if (!visible)
+				return;
+			files.value = part;
+			visible.style.display = 'block';
+			location.hash = part;
+		}
+		function onChange() {
+			select(files.value);
+			window.scrollTo(0, 0);
+		}
+		if (location.hash != "") {
+			select(location.hash.substr(1));
+		}
+		if (!visible) {
+			select("file0");
+		}
+	})();
+	</script>
+</html>


### PR DESCRIPTION
This pull request adds a `Makefile` to streamline build and testing processes and introduces an `aqua.yaml` configuration file for managing CLI tools declaratively. These changes aim to improve developer workflows and ensure consistency in tool versions.

### Build and testing improvements:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52R1-R26): Introduced a new `Makefile` with targets for `build`, `init`, `format`, and `test`. The `test` target supports verbosity based on the `TEST_VERBOSE` flag, and the `build` target compiles the `github-stats` binary.

### Declarative CLI tool management:

* [`aqua.yaml`](diffhunk://#diff-1b3ff13ada3533724a2a1419cda40f0044d1cbda882bc61b771dcd3eae32fd1cR1-R15): Added an `aqua.yaml` file for declarative CLI version management using Aqua, specifying the registry version and including `golang/go` as a managed package.